### PR TITLE
Integ tests

### DIFF
--- a/docs/pages/iam/iam-commands.md
+++ b/docs/pages/iam/iam-commands.md
@@ -26,8 +26,8 @@ Usage:
 create-role [options] [identifier]
 
   Options:
-    -p, --preset-config <identifier>       select a role configuration already defined by @lager/iam
-    --managed-policies <managed-policies>  select the managed policies to apply to the role
+    -m, --model <model-identifier>       select a model to quickly create the role configuration
+    -p, --policies <policy-identifiers>  select the policies to attach to the role
 ```
 
 Create a new role in `iam/roles/<identifier>.json`.

--- a/docs/pages/tutorials/lamdba-profiling.md
+++ b/docs/pages/tutorials/lamdba-profiling.md
@@ -23,7 +23,7 @@ lager new lambda-profiling @lager/iam @lager/node-lambda
 We create a simple execution role for our Lambdas.
 
 ```bash
-lager create-role LambdaInspection -p LambdaBasicExecutionRole
+lager create-role LambdaInspection -m LambdaBasicExecutionRole
 ```
 
 We create a node module called `inspection`. It will inspect its own execution environment.

--- a/docs/pages/tutorials/planet-express.md
+++ b/docs/pages/tutorials/planet-express.md
@@ -84,7 +84,7 @@ The Lambda needs to be associated to an IAM role that defines its authorizations
 implementation of the application. For now, we use a role that allows the Lambda to write logs in CloudWatch.
 
 ```bash
-lager create-role PlanetExpressLambdaExecution -p LambdaBasicExecutionRole
+lager create-role PlanetExpressLambdaExecution -m LambdaBasicExecutionRole
 ```
 
 #### Creation of node modules that can be packaged in the Lambda
@@ -132,7 +132,7 @@ lager create-api recipient   -t "Recipient"   -d "Planet Express API for recipie
 The API endpoints need to be associated to an IAM role that allows to invoke the Lambda.
 
 ```bash
-lager create-role PlanetExpressLambdaInvocation -p APIGatewayLambdaInvocation
+lager create-role PlanetExpressLambdaInvocation -m APIGatewayLambdaInvocation
 ```
 
 #### Creation of the endpoints
@@ -162,7 +162,7 @@ npm install -g @lager/cli
 lager new planet-express @lager/iam @lager/api-gateway @lager/node-lambda
 cd planet-express
 
-lager create-role PlanetExpressLambdaExecution -p LambdaBasicExecutionRole
+lager create-role PlanetExpressLambdaExecution -m LambdaBasicExecutionRole
 
 lager create-node-module log
 lager create-node-module data-access -d log
@@ -173,7 +173,7 @@ lager create-api back-office -t "Back Office" -d "Planet Express API for Back Of
 lager create-api sender      -t "Sender"      -d "Planet Express API for sender application"
 lager create-api recipient   -t "Recipient"   -d "Planet Express API for recipient application"
 
-lager create-role PlanetExpressLambdaInvocation -p APIGatewayLambdaInvocation
+lager create-role PlanetExpressLambdaInvocation -m APIGatewayLambdaInvocation
 
 lager create-endpoint /delivery get -a back-office,recipient,sender -s "View a delivery" -i lambda-proxy --auth none --credentials PlanetExpressLambdaInvocation -l api-generic
 lager create-endpoint /delivery patch -a back-office -s "View a delivery" -i lambda-proxy --auth none --credentials PlanetExpressLambdaInvocation -l api-generic

--- a/packages/cli/src/bin/lager
+++ b/packages/cli/src/bin/lager
@@ -1,21 +1,22 @@
 #!/usr/bin/env node
 'use strict';
 
+const icli = require('comquirer');
 
 if (['dev', 'development', 'debug'].indexOf(process.env.NODE_ENV) > -1) {
   process.on('uncaughtException', (e) => {
-    console.log(e, 'Unhandled Exception');
+    process.stderr.write('\n  Uncaught Exception\n\n');
+    process.stderr.write(e.stack + '\n');
     process.exit(1);
   });
 
   process.on('unhandledRejection', (reason, promise) => {
-    console.log({promise: promise, reason: reason}, 'Unhandled Rejection');
+    process.stderr.write('\n  Unhandled Rejection\n\n');
+    process.stderr.write('Promise: ' + JSON.stringify(promise, null, 2) + '\n\n');
+    process.stderr.write('Reason: ' + (reason instanceof Error ? reason.stack : JSON.stringify(reason, null, 2)) + '\n');
     process.exit(1);
   });
 }
-
-
-const icli = require('comquirer');
 
 icli.init = function() {
   // Useful to reinit the cli for integration tests
@@ -52,7 +53,7 @@ if (require.main === module) {
       // If no arguments where provided, we call the help option
       icli.getProgram().outputHelp();
     } else {
-      icli.getProgram().parse(process.argv);
+      icli.parse(process.argv);
     }
   });
 }

--- a/packages/iam/src/cli/deploy-policies.js
+++ b/packages/iam/src/cli/deploy-policies.js
@@ -93,13 +93,13 @@ module.exports = (icli) => {
     .then(policies => {
       return Promise.map(policies, policy => { return policy.deploy(context); });
     })
-    .then(results => {
+    .then(reports => {
       const t = new Table();
-      _.forEach(results, result => {
-        t.cell('Name', result.report.name);
-        t.cell('Operation', result.report.operation);
-        t.cell('ARN', result.report.arn);
-        t.cell('Deploy time', formatHrTime(result.report.deployTime));
+      _.forEach(reports, report => {
+        t.cell('Name', report.name);
+        t.cell('Operation', report.operation);
+        t.cell('ARN', report.arn);
+        t.cell('Deploy time', formatHrTime(report.deployTime));
         t.newRow();
       });
       console.log();

--- a/packages/iam/src/index.js
+++ b/packages/iam/src/index.js
@@ -161,7 +161,6 @@ function findRoles(identifiers) {
 }
 
 /**
- * @TODO check duplication with iam/helper.retrieveRoleArn()
  * Takes a role ARN, or a role name as parameter, requests AWS,
  * and retruns the ARN of a role matching the ARN or the role name or the role name with context informations
  * @param  {string} identifier - a role ARN, or a role name

--- a/packages/iam/src/policy.js
+++ b/packages/iam/src/policy.js
@@ -67,7 +67,7 @@ Policy.prototype.deploy = function deploy(context) {
     return plugin.lager.fire('afterDeployPolicy', this);
   })
   .spread(() => {
-    return Promise.resolve({ report });
+    return Promise.resolve(report);
   });
 };
 

--- a/packages/iam/src/role.js
+++ b/packages/iam/src/role.js
@@ -53,7 +53,7 @@ Role.prototype.deploy = function deploy(context) {
   .spread(() => {
     return Promise.promisify(awsIAM.getRole.bind(awsIAM))({ RoleName: name })
     .catch(e => {
-      // We silently ignore the error if the role is not found : we will have to create it
+      // We silently ignore the error if the role is not found: we will have to create it
       if (e.code === 'NoSuchEntity') { return Promise.resolve(null); }
       return Promise.reject(e);
     });

--- a/packages/iam/test/policy.test.js
+++ b/packages/iam/test/policy.test.js
@@ -143,20 +143,20 @@ describe('An IAM policy', () => {
 
   it('should be created for the first deployment', function() {
     return policy.deploy(context)
-    .then(result => {
-      assert.equal(result.report.name, 'TEST_MyPolicy_v0');
-      assert.equal(result.report.operation, 'Creation');
-      assert.equal(result.report.policyVersions, 1);
+    .then(report => {
+      assert.equal(report.name, 'TEST_MyPolicy_v0');
+      assert.equal(report.operation, 'Creation');
+      assert.equal(report.policyVersions, 1);
     });
   });
 
 
   it('should not add "_" to the policy name when the Lager "context" does not provide environment or stage', function() {
     return policy.deploy({ environment: '', stage: '' })
-    .then(result => {
-      assert.equal(result.report.name, 'MyPolicy');
-      assert.equal(result.report.operation, 'Creation');
-      assert.equal(result.report.policyVersions, 1);
+    .then(report => {
+      assert.equal(report.name, 'MyPolicy');
+      assert.equal(report.operation, 'Creation');
+      assert.equal(report.policyVersions, 1);
     });
   });
 
@@ -164,9 +164,9 @@ describe('An IAM policy', () => {
   it('should not be updated for the second deployment if the document is the same', function() {
     listPolicies.Policies[0].PolicyName = 'TEST_MyPolicy_v0';
     return policy.deploy(context)
-    .then(result => {
-      assert.equal(result.report.name, 'TEST_MyPolicy_v0');
-      assert.equal(result.report.operation, 'Already up-to-date');
+    .then(report => {
+      assert.equal(report.name, 'TEST_MyPolicy_v0');
+      assert.equal(report.operation, 'Already up-to-date');
     });
   });
 
@@ -174,10 +174,10 @@ describe('An IAM policy', () => {
   it('should be updated for the second deployment if the document is different', function() {
     policy.document.Statement[0].Action = ['xxx'];
     return policy.deploy(context)
-    .then(result => {
-      assert.equal(result.report.name, 'TEST_MyPolicy_v0');
-      assert.equal(result.report.operation, 'Update');
-      assert.equal(result.report.policyVersions, 1);
+    .then(report => {
+      assert.equal(report.name, 'TEST_MyPolicy_v0');
+      assert.equal(report.operation, 'Update');
+      assert.equal(report.policyVersions, 1);
     });
   });
 
@@ -185,11 +185,11 @@ describe('An IAM policy', () => {
   it('should delete the most ancient version if there are already 5', function() {
     listPolicyVersions = listPolicyVersions5;
     return policy.deploy(context)
-    .then(result => {
-      assert.equal(result.report.name, 'TEST_MyPolicy_v0');
-      assert.equal(result.report.operation, 'Update');
-      assert.equal(result.report.deletedVersion, 'v1');
-      assert.equal(result.report.policyVersions, 5);
+    .then(report => {
+      assert.equal(report.name, 'TEST_MyPolicy_v0');
+      assert.equal(report.operation, 'Update');
+      assert.equal(report.deletedVersion, 'v1');
+      assert.equal(report.policyVersions, 5);
     });
   });
 

--- a/packages/lager/src/lib/lager.js
+++ b/packages/lager/src/lib/lager.js
@@ -13,7 +13,7 @@ if (['dev', 'development', 'debug'].indexOf(process.env.NODE_ENV) > -1) {
   });
 
   process.on('uncaughtException', (e) => {
-    log.fatal(e, 'Unhandled Exception');
+    log.fatal(e, 'Uncaught Exception');
     process.exit(1);
   });
 

--- a/test/iam/cli.integ.js
+++ b/test/iam/cli.integ.js
@@ -41,11 +41,33 @@ describe('Definition of IAM permissions', () => {
 
   it('should allow to deploy policies', () => {
     catchStdout.start(showStdout);
-    return icli.parse('node script.js deploy-policies integration-test-policy -e TEST -s v0'.split(' '))
+    return icli.parse('node script.js deploy-policies integration-test-policy -e TEST -s x'.split(' '))
     .then(res => {
       const stdout = catchStdout.stop();
       assert.ok(stdout.indexOf('Policies deployed') > -1);
-      assert.ok(stdout.indexOf('TEST_integration-test-policy_v0') > -1);
+      assert.ok(stdout.indexOf('TEST_integration-test-policy_x') > -1);
+    });
+  });
+
+  it('should allow to define roles', () => {
+    catchStdout.start(showStdout);
+    return icli.parse('node script.js create-role integration-test-role -m none -p integration-test-policy'.split(' '))
+    .then(res => {
+      const stdout = catchStdout.stop();
+      assert.ok(stdout.indexOf('The IAM role \x1b[36mintegration-test-role\x1b[0m has been created') > -1);
+      const path = icli.lager.getConfig('iam.rolesPath');
+      const role = require('./' + path + '/integration-test-role');
+      assert.equal(role['managed-policies'][0], 'integration-test-policy');
+    });
+  });
+
+  it('should allow to deploy roles', () => {
+    catchStdout.start(showStdout);
+    return icli.parse('node script.js deploy-roles integration-test-role -e TEST -s x'.split(' '))
+    .then(res => {
+      const stdout = catchStdout.stop();
+      assert.ok(stdout.indexOf('Roles deployed') > -1);
+      assert.ok(stdout.indexOf('TEST_integration-test-role_x') > -1);
     });
   });
 

--- a/test/lambda-profiling/cli.integ.js
+++ b/test/lambda-profiling/cli.integ.js
@@ -29,7 +29,7 @@ describe('Creation and deployment of a Lambda project', () => {
 
   describe('Creation of an execution role', () => {
     it('should be done via the sub-command "create-role"', () => {
-      return icli.parse('node script.js create-role LambdaInspection -p LambdaBasicExecutionRole'.split(' '))
+      return icli.parse('node script.js create-role LambdaInspection -m LambdaBasicExecutionRole'.split(' '))
       .then(res => {
         assert.ok(true);
       });

--- a/test/planet-express/cli.integ.js
+++ b/test/planet-express/cli.integ.js
@@ -29,7 +29,7 @@ describe('Creation and deployment of the Planet Express project', () => {
 
   describe('Creation of an execution role', () => {
     it('should be done via the sub-command "create-role"', () => {
-      return icli.parse('node script.js create-role PlanetExpressLambdaExecution -p LambdaBasicExecutionRole'.split(' '))
+      return icli.parse('node script.js create-role PlanetExpressLambdaExecution -m LambdaBasicExecutionRole'.split(' '))
       .then(res => {
         assert.ok(true);
       });
@@ -66,7 +66,7 @@ describe('Creation and deployment of the Planet Express project', () => {
 
   describe('Creation of an invocation role', () => {
     it('should be done via the sub-command "create-role"', () => {
-      return icli.parse('node script.js create-role PlanetExpressLambdaInvocation -p APIGatewayLambdaInvocation'.split(' '))
+      return icli.parse('node script.js create-role PlanetExpressLambdaInvocation -m APIGatewayLambdaInvocation'.split(' '))
       .then(res => {
         assert.ok(true);
       });


### PR DESCRIPTION
Add new integration test for `create-role` and `deploy-roles` commands.
Change options names of `create-role`
Automatically deploy policies associated to a role if they do not exist in AWS